### PR TITLE
Update MNIST example

### DIFF
--- a/Examples/MNIST/extract_weights_biases.py
+++ b/Examples/MNIST/extract_weights_biases.py
@@ -11,17 +11,17 @@ model = h5py.File('dense-256-512-256.h5', 'r')
 # Get weights. Note weight matrices are transposed because the PLC ML Inference Framework reads weights that way
 weights = model['model_weights']
 
-L1_biases = np.array(weights['dense']['dense']['bias:0'], dtype='float64')
-L1_weights = np.array(weights['dense']['dense']['kernel:0'], dtype='float64').transpose()
+L1_biases = np.array(weights['dense']['sequential']['dense']['bias'], dtype='float64')
+L1_weights = np.array(weights['dense']['sequential']['dense']['kernel'], dtype='float64').transpose()
 
-L2_biases = np.array(weights['dense_1']['dense_1']['bias:0'], dtype='float64')
-L2_weights = np.array(weights['dense_1']['dense_1']['kernel:0'], dtype='float64').transpose()
+L2_biases = np.array(weights['dense_1']['sequential']['dense_1']['bias'], dtype='float64')
+L2_weights = np.array(weights['dense_1']['sequential']['dense_1']['kernel'], dtype='float64').transpose()
 
-L3_biases = np.array(weights['dense_2']['dense_2']['bias:0'], dtype='float64')
-L3_weights = np.array(weights['dense_2']['dense_2']['kernel:0'], dtype='float64').transpose()
+L3_biases = np.array(weights['dense_2']['sequential']['dense_2']['bias'], dtype='float64')
+L3_weights = np.array(weights['dense_2']['sequential']['dense_2']['kernel'], dtype='float64').transpose()
 
-L4_biases = np.array(weights['dense_3']['dense_3']['bias:0'], dtype='float64')
-L4_weights = np.array(weights['dense_3']['dense_3']['kernel:0'], dtype='float64').transpose()
+L4_biases = np.array(weights['dense_3']['sequential']['dense_3']['bias'], dtype='float64')
+L4_weights = np.array(weights['dense_3']['sequential']['dense_3']['kernel'], dtype='float64').transpose()
 
 # Create weights and biases directory
 if not os.path.exists('plc_mnist_weights'):

--- a/Examples/MNIST/mnist_model.py
+++ b/Examples/MNIST/mnist_model.py
@@ -20,7 +20,7 @@ def normalize_img(image, label):
 
 def np_flatten_img(image, label):
     """Flattens image"""
-    return tf.reshape(image, [1, 784]), label
+    return tf.reshape(image, (-1,)), label
 
 
 ds_train = ds_train.map(

--- a/Examples/MNIST/mnist_model.py
+++ b/Examples/MNIST/mnist_model.py
@@ -42,7 +42,7 @@ ds_test = ds_test.prefetch(tf.data.AUTOTUNE)
 
 # Create Model
 model = tf.keras.models.Sequential([
-    tf.keras.layers.InputLayer(input_shape=(784, )),
+    tf.keras.layers.InputLayer(shape=(784, )),
     tf.keras.layers.Dense(256, activation='relu'),
     tf.keras.layers.Dense(512, activation='relu'),
     tf.keras.layers.Dense(256, activation='relu'),


### PR DESCRIPTION
This PR solves issues for the Python code inside the MNIST example. The issues likely stem from updates to Tensorflow over the years.

- `input_shape` is deprecated in input layers. Updated to `shape`.
- flatten image to 1D array instead of [1, 174]. The 2D array caused an exception in `model.fit`.
- Extract weights keys updated. Tensorflow likely updated how they save models.

If need be I can post logs of the errors before this PR is merged.